### PR TITLE
Add installed version to status field of apicurio crd

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/apicuriodeployment_types.go
+++ b/pkg/apis/integreatly/v1alpha1/apicuriodeployment_types.go
@@ -13,18 +13,19 @@ const (
 )
 
 type ApicurioDeploymentSpec struct {
-	Version         string     `json:"version"`
-	AppDomain       string     `json:"app_domain"`
-	Template        string     `json:"template"`
-	ExternalAuthUrl string     `json:"external_auth_url"`
-	AuthRealm       string     `json:"auth_realm"`
-	JvmHeap         [2]string  `json:"jvm_heap"`
-	MemLimit        [2]string  `json:"mem_limit"`
+	Version         string    `json:"version"`
+	AppDomain       string    `json:"app_domain"`
+	Template        string    `json:"template"`
+	ExternalAuthUrl string    `json:"external_auth_url"`
+	AuthRealm       string    `json:"auth_realm"`
+	JvmHeap         [2]string `json:"jvm_heap"`
+	MemLimit        [2]string `json:"mem_limit"`
 }
 
 // ApicurioDeploymentStatus defines the observed state of ApicurioDeployment
 type ApicurioDeploymentStatus struct {
 	Message string `json:"message"`
+	Version string `json:"version"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -43,8 +44,8 @@ type ApicurioDeployment struct {
 
 // ApicurioDeploymentList contains a list of ApicurioDeployment
 type ApicurioDeploymentList struct {
-	metav1.TypeMeta                      `json:",inline"`
-	metav1.ListMeta                      `json:"metadata,omitempty"`
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ApicurioDeployment `json:"items"`
 }
 


### PR DESCRIPTION
## What
Add the version of the Apicurio installed within the `status` field of the Apicurio CRD.

## Why
Ensure that the version of the product installed by the Apicurio operator is reflected in the `status.version` field.

## Verification Steps
1. Run `make cluster/prepare`
2. Run the operator locally.
3. Create the Apicurio custom resource
4. Ensure that the correct version is shown within the `status` field of the Apicurio custom resource

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member
