### PR TITLE
removing @packr clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,9 @@ code/fix:
 
 .PHONY: image/build
 image/build: code/compile
+	@packr
 	@operator-sdk build ${REG}/${ORG}/${IMAGE}:${TAG}
+	@packr clean
 
 .PHONY: image/push
 image/push:
@@ -89,6 +91,7 @@ test/e2e/cluster: image/build/test image/push
 image/build/test:
 	@packr
 	operator-sdk build --enable-tests ${REG}/${ORG}/${IMAGE}:${TAG}
+	@packr clean
 
 .PHONY: cluster/prepare
 cluster/prepare:


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/INTLY-340

removes `@packr clean` since it was deleting the required packr file.

We remove the file in the `code/compile` target but then run `image/build` and the packr file is gone by the time the operator-sdk re-builds the go project.